### PR TITLE
Do not print catched exeption

### DIFF
--- a/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/storage/transformation_schema/reader/XmlFileReader.java
+++ b/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/storage/transformation_schema/reader/XmlFileReader.java
@@ -14,10 +14,8 @@ package plugins.fr.univ_nantes.ec_clem.ec_clem.storage.transformation_schema.rea
 
 import icy.util.XMLUtil;
 import org.w3c.dom.Document;
-
 import javax.inject.Inject;
 import java.io.File;
-import java.io.IOException;
 
 public class XmlFileReader {
 
@@ -25,20 +23,6 @@ public class XmlFileReader {
     public XmlFileReader() {}
 
     public Document loadFile(File XMLFile) {
-//        checkFileExists(XMLFile);
         return XMLUtil.loadDocument(XMLFile, true);
     }
-
-//    private void checkFileExists(File XMLFile) {
-//        if(!XMLFile.exists()) {
-//            try {
-//                XMLFile.createNewFile();
-//            } catch (IOException e) {
-//                e.printStackTrace();
-//            }
-//            Document document = XMLUtil.createDocument(true);
-//            XmlFileWriter xmlFileWriter = new XmlFileWriter(document, XMLFile);
-//            xmlFileWriter.write();
-//        }
-//    }
 }

--- a/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/ui/ComputeErrorMapButton.java
+++ b/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/ui/ComputeErrorMapButton.java
@@ -59,7 +59,6 @@ public class ComputeErrorMapButton extends JButton {
                         .setColorMap(new FireColorMap(), false);
                 }));
         } catch(RuntimeException e) {
-            e.printStackTrace();
             MessageDialog.showDialog(e.getMessage(), MessageDialog.ERROR_MESSAGE);
         }
     }

--- a/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/ui/MergeButton.java
+++ b/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/ui/MergeButton.java
@@ -27,7 +27,6 @@ public class MergeButton extends JButton {
                     new Viewer(sequence);
                 }));
         } catch(RuntimeException e) {
-            e.printStackTrace();
             MessageDialog.showDialog(e.getMessage(), MessageDialog.ERROR_MESSAGE);
         }
     }

--- a/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/ui/UpdateTransformationButton.java
+++ b/src/main/java/plugins/fr/univ_nantes/ec_clem/ec_clem/ui/UpdateTransformationButton.java
@@ -37,7 +37,6 @@ public class UpdateTransformationButton extends JButton {
         WorkspaceTransformer workspaceTransformer = new WorkspaceTransformer(workspace);
         progressBarManager.subscribe(workspaceTransformer);
         CompletableFuture.runAsync(workspaceTransformer).exceptionally(e -> {
-            e.printStackTrace();
             MessageDialog.showDialog(e.getCause().getMessage(), MessageDialog.ERROR_MESSAGE);
             return null;
         });


### PR DESCRIPTION
Catched exeptions from UI component display an error popup but are no longer printed in output